### PR TITLE
LastY variable was added to settings

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -47,6 +47,7 @@
                                     textRequired: false, // will input loader text if true
                                     scrollWheelSelected: false, // will use scroll wheel events
                                     swipeDistance: 50, // swipe distance for loader to show on touch devices
+                                    lastYDistance: 40, // minimum Y coordinate for triggering reloading on touch devices
                                     loaderClass: 'hook-loader',
                                     spinnerClass: 'hook-spinner',
                                     loaderTextClass: 'hook-text',
@@ -102,7 +103,7 @@
                                   e.preventDefault();
                                 }
 
-                                if(swipe > settings.swipeDistance && lastY <= 40) {
+                                if(swipe > settings.swipeDistance && lastY <= settings.lastYDistance) {
                                     methods.onSwipe($this, settings);
                                 }
                             });


### PR DESCRIPTION
Hello!
I suggest to add variable lastY to settings object. I think it will be good, if developer will have ability to set this value via settings. It can be useful for pages  viewed on mobile devices. I think that default value (=40) is too small for some applications. When I added hook.js to my mobile application, I thought that it didn't work first time, because when I scrolled the page, my finger clicked on the middle of the screen and nothing happened (because lastY was more than 40)), so I guess that placing lastY to settings could do this library more flexible.
